### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Pillow==9.0.1
-altair==4.2.0rc1
+Pillow==9.2.0
+altair==4.2.0
 clarifai-grpc==8.6.0
-clarifai-utils==0.1.6
-numpy==1.22.0
-pandas==1.3.4
-requests==2.26.0
+clarifai-utils==0.1.9
+numpy==1.23.1
+pandas==1.4.3
+requests==2.28.1
 stqdm==0.0.4
 streamlit==1.10.0
 vega-datasets==0.9.0


### PR DESCRIPTION
Update to the latest deps

Tested with Python 3.9

vega-datasets is used for testing streamit, maybe we could replace it with something else because people will bring it to their app and won't use it. 